### PR TITLE
Send light brightness before turning on to avoid a flash

### DIFF
--- a/aiomodernforms/modernforms.py
+++ b/aiomodernforms/modernforms.py
@@ -281,7 +281,12 @@ class ModernFormsDevice:
         on: bool | None = None,
         sleep: int | datetime | None = None,
     ):
-        """Change Fans Light state."""
+        """Change Fans Light state.
+
+        When both brightness and on=True are given, brightness is sent in
+        its own request first to avoid the fan briefly flashing at the
+        previous brightness. See issue #99.
+        """
         if self._device is None:
             await self.update()
 

--- a/aiomodernforms/modernforms.py
+++ b/aiomodernforms/modernforms.py
@@ -284,33 +284,40 @@ class ModernFormsDevice:
         """Change Fans Light state."""
         if self._device is None:
             await self.update()
-        commands: dict[str, bool | int] = {}
 
-        if brightness is not None:
-            if (
-                not isinstance(brightness, int)
-                or int(brightness) < LIGHT_BRIGHTNESS_LOW_VALUE
-                or int(brightness) > LIGHT_BRIGHTNESS_HIGH_VALUE
-            ):
-                raise ModernFormsInvalidSettingsError(
-                    "brightness value must be between"
-                    + f" {LIGHT_BRIGHTNESS_LOW_VALUE} and {LIGHT_BRIGHTNESS_HIGH_VALUE}"
-                )
-
-            commands[COMMAND_LIGHT_BRIGHTNESS] = brightness
-
-        if on is not None:
-            if not isinstance(on, bool):
-                raise ModernFormsInvalidSettingsError("on must be a boolean")
-
-            commands[COMMAND_LIGHT_POWER] = on
-
-        if sleep is not None:
-            commands.update(
-                self._sleep_command(
-                    COMMAND_LIGHT_SLEEP_TIMER, COMMAND_LIGHT_TIMER, sleep
-                )
+        if brightness is not None and (
+            not isinstance(brightness, int)
+            or int(brightness) < LIGHT_BRIGHTNESS_LOW_VALUE
+            or int(brightness) > LIGHT_BRIGHTNESS_HIGH_VALUE
+        ):
+            raise ModernFormsInvalidSettingsError(
+                "brightness value must be between"
+                + f" {LIGHT_BRIGHTNESS_LOW_VALUE} and {LIGHT_BRIGHTNESS_HIGH_VALUE}"
             )
+
+        if on is not None and not isinstance(on, bool):
+            raise ModernFormsInvalidSettingsError("on must be a boolean")
+
+        sleep_commands: dict[str, int] = {}
+        if sleep is not None:
+            sleep_commands = self._sleep_command(
+                COMMAND_LIGHT_SLEEP_TIMER, COMMAND_LIGHT_TIMER, sleep
+            )
+
+        if brightness is not None and on is True:
+            # Setting brightness and turning on in a single request makes the
+            # fan briefly show the previous brightness before jumping to the
+            # new one. Sending brightness first avoids the flash.
+            await self.request(commands={COMMAND_LIGHT_BRIGHTNESS: brightness})
+            await self.request(commands={COMMAND_LIGHT_POWER: on, **sleep_commands})
+            return
+
+        commands: dict[str, bool | int] = {}
+        if brightness is not None:
+            commands[COMMAND_LIGHT_BRIGHTNESS] = brightness
+        if on is not None:
+            commands[COMMAND_LIGHT_POWER] = on
+        commands.update(sleep_commands)
 
         await self.request(commands=commands)
 

--- a/docs/superpowers/plans/2026-07-27-light-brightness-before-on.md
+++ b/docs/superpowers/plans/2026-07-27-light-brightness-before-on.md
@@ -1,0 +1,277 @@
+# Light Brightness-Before-On Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix [issue #99](https://github.com/wonderslug/aiomodernforms/issues/99) — turning a light on with a new brightness in one `light()` call causes a visible flash at the old brightness, because both fields are sent in a single HTTP request.
+
+**Architecture:** `ModernFormsDevice.light()` in `aiomodernforms/modernforms.py` currently builds one combined `commands` dict for `brightness`, `on`, and `sleep`, and sends it in a single `self.request()` call. This plan changes `light()` so that when `brightness is not None and on is True`, it sends two sequential requests — brightness first, then `on` (+ `sleep`) — instead of one. All other argument combinations keep the existing single-request behavior.
+
+**Tech Stack:** Python 3.11, `aiohttp`, `pytest` + `pytest-asyncio` + `aresponses` for HTTP-mocked tests.
+
+## Global Constraints
+
+- Validation of `brightness` and `on` must happen before any HTTP request is sent (no partial device state on invalid input) — spec's "Design" step 1.
+- Only the `brightness is not None and on is True` combination gets split into two requests; every other combination (brightness alone, on alone, `on=False` + brightness) stays a single combined request — spec's "Scope".
+- `light()` continues to return nothing — callers read `device.status` afterward, matching its current signature.
+- No new imports are needed: `COMMAND_LIGHT_BRIGHTNESS`, `COMMAND_LIGHT_POWER`, `COMMAND_LIGHT_SLEEP_TIMER`, `COMMAND_LIGHT_TIMER`, `LIGHT_BRIGHTNESS_LOW_VALUE`, `LIGHT_BRIGHTNESS_HIGH_VALUE`, and `ModernFormsInvalidSettingsError` are already imported in `aiomodernforms/modernforms.py`.
+
+---
+
+### Task 1: Split brightness-then-on requests in `light()`
+
+**Files:**
+- Modify: `aiomodernforms/modernforms.py:277-315` (the `light()` method)
+- Test: `tests/test_aiomodernforms.py:336-375` (replace existing `test_light`), plus three new tests added directly after it
+
+**Interfaces:**
+- Consumes: `ModernFormsDevice.request(commands: dict | None)` (existing, unchanged) and `ModernFormsDevice._sleep_command(epoch_command, relative_command, sleep)` (existing, unchanged) — both already used by the current `light()` implementation.
+- Produces: `ModernFormsDevice.light(*, brightness: int | None = None, on: bool | None = None, sleep: int | datetime | None = None) -> None` — same signature and return type as before; only the internal request pattern changes for the `brightness` + `on=True` combination.
+
+- [ ] **Step 1: Replace `test_light` with a version asserting the two-request split**
+
+In `tests/test_aiomodernforms.py`, replace the entire existing `test_light` function (lines 336-375, from `@pytest.mark.asyncio` through the final assert) with:
+
+```python
+@pytest.mark.asyncio
+async def test_light(aresponses):
+    """Test that turning on with a brightness sends brightness before on."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_brightness_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        assert aiomodernforms.COMMAND_LIGHT_POWER not in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    async def evaluate_on_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
+        modified_response = basic_response.copy()
+        modified_response[
+            STATE_LIGHT_BRIGHTNESS
+        ] = aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        modified_response[STATE_LIGHT_SLEEP_TIMER] = data[
+            aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_brightness_request)
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_on_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        sleep_time = datetime.now() + timedelta(minutes=2)
+        await device.light(
+            on=aiomodernforms.LIGHT_POWER_ON,
+            brightness=aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE,
+            sleep=sleep_time,
+        )
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_ON
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+        assert device.status.light_sleep_timer == int(sleep_time.timestamp())
+```
+
+Note: `aresponses` serves queued responses in order — two for `device.update()`, then one each for the brightness request and the on+sleep request. If `light()` still sends only one request, the third `aresponses.add` response (`evaluate_brightness_request`) will be consumed by that single request, its assertions will fail (since a combined request contains `lightOn`, which `evaluate_brightness_request` asserts is absent), producing the expected failure.
+
+- [ ] **Step 2: Add three regression tests immediately after `test_light`**
+
+Insert these three new test functions directly after the `test_light` function you just replaced (before `test_light_sleep_datetime`):
+
+```python
+@pytest.mark.asyncio
+async def test_light_off_with_brightness_single_request(aresponses):
+    """Test that turning off with a brightness change stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(
+            on=aiomodernforms.LIGHT_POWER_OFF,
+            brightness=aiomodernforms.LIGHT_BRIGHTNESS_LOW_VALUE,
+        )
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_OFF
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_LOW_VALUE
+        )
+
+
+@pytest.mark.asyncio
+async def test_light_brightness_only_single_request(aresponses):
+    """Test that changing only brightness stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        assert aiomodernforms.COMMAND_LIGHT_POWER not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(brightness=aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE)
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+
+
+@pytest.mark.asyncio
+async def test_light_on_only_single_request(aresponses):
+    """Test that turning on without a brightness stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(on=aiomodernforms.LIGHT_POWER_ON)
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_ON
+```
+
+These three exercise argument combinations that are *not* changing behavior. Each registers exactly one `aresponses.add` for the `light()` call itself — if `light()` ever sent two requests for these combinations, the second request would have no queued response left and the test would fail. They act as regression guards against over-splitting.
+
+- [ ] **Step 3: Run the light tests and confirm the expected mixed result**
+
+Run: `.venv/bin/pytest tests/test_aiomodernforms.py -k light -v`
+
+Expected: `test_light` **FAILS** (current `light()` still sends a single combined request, so `evaluate_brightness_request`'s `assert aiomodernforms.COMMAND_LIGHT_POWER not in data` fails). The three new regression tests **PASS** (their argument combinations already produce single requests under the current implementation, so they're unaffected by this step and will continue to pass after Step 4).
+
+- [ ] **Step 4: Implement the brightness-before-on split in `light()`**
+
+In `aiomodernforms/modernforms.py`, replace the `light()` method (lines 277-315) with:
+
+```python
+    async def light(
+        self,
+        *,
+        brightness: int | None = None,
+        on: bool | None = None,
+        sleep: int | datetime | None = None,
+    ):
+        """Change Fans Light state."""
+        if self._device is None:
+            await self.update()
+
+        if brightness is not None and (
+            not isinstance(brightness, int)
+            or int(brightness) < LIGHT_BRIGHTNESS_LOW_VALUE
+            or int(brightness) > LIGHT_BRIGHTNESS_HIGH_VALUE
+        ):
+            raise ModernFormsInvalidSettingsError(
+                "brightness value must be between"
+                + f" {LIGHT_BRIGHTNESS_LOW_VALUE} and {LIGHT_BRIGHTNESS_HIGH_VALUE}"
+            )
+
+        if on is not None and not isinstance(on, bool):
+            raise ModernFormsInvalidSettingsError("on must be a boolean")
+
+        sleep_commands: dict[str, int] = {}
+        if sleep is not None:
+            sleep_commands = self._sleep_command(
+                COMMAND_LIGHT_SLEEP_TIMER, COMMAND_LIGHT_TIMER, sleep
+            )
+
+        if brightness is not None and on is True:
+            # Setting brightness and turning on in a single request makes the
+            # fan briefly show the previous brightness before jumping to the
+            # new one. Sending brightness first avoids the flash.
+            await self.request(commands={COMMAND_LIGHT_BRIGHTNESS: brightness})
+            await self.request(commands={COMMAND_LIGHT_POWER: on, **sleep_commands})
+            return
+
+        commands: dict[str, bool | int] = {}
+        if brightness is not None:
+            commands[COMMAND_LIGHT_BRIGHTNESS] = brightness
+        if on is not None:
+            commands[COMMAND_LIGHT_POWER] = on
+        commands.update(sleep_commands)
+
+        await self.request(commands=commands)
+```
+
+This preserves the original validation order (brightness, then `on`, then `sleep` via `_sleep_command`) so `test_invalid_setting` (which checks each raises `ModernFormsInvalidSettingsError` with zero HTTP calls) keeps passing unchanged.
+
+- [ ] **Step 5: Run the light tests again and confirm all pass**
+
+Run: `.venv/bin/pytest tests/test_aiomodernforms.py -k light -v`
+
+Expected: **PASS** — all light tests green, including the rewritten `test_light` and the three new regression tests.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `.venv/bin/pytest tests/test_aiomodernforms.py -v`
+
+Expected: **PASS** — no other test touches `light()`'s internals, but this confirms nothing else regressed (e.g. `test_invalid_setting`, which exercises `light()` validation paths).
+
+- [ ] **Step 7: Run pre-commit checks (matches CI)**
+
+Run: `pre-commit run --all-files --show-diff-on-failure`
+
+Expected: **PASS**. This repo's CI (`.github/workflows/ci.yml`) runs `pre-commit run --all-files` (black, flake8, isort, mypy, pylint, etc.) before the test job; running it locally now catches formatting/lint issues before commit. If black reformats the new code, re-run the test suite (Step 6) to confirm nothing broke.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add aiomodernforms/modernforms.py tests/test_aiomodernforms.py
+git commit -m "Send light brightness before turning on to avoid a flash (#99)"
+```

--- a/docs/superpowers/plans/2026-07-27-light-brightness-before-on.md
+++ b/docs/superpowers/plans/2026-07-27-light-brightness-before-on.md
@@ -59,9 +59,9 @@ async def test_light(aresponses):
         assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER in data
         assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
         modified_response = basic_response.copy()
-        modified_response[
-            STATE_LIGHT_BRIGHTNESS
-        ] = aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        modified_response[STATE_LIGHT_BRIGHTNESS] = (
+            aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
         modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
         modified_response[STATE_LIGHT_SLEEP_TIMER] = data[
             aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER
@@ -201,52 +201,52 @@ Expected: `test_light` **FAILS** (current `light()` still sends a single combine
 In `aiomodernforms/modernforms.py`, replace the `light()` method (lines 277-315) with:
 
 ```python
-    async def light(
-        self,
-        *,
-        brightness: int | None = None,
-        on: bool | None = None,
-        sleep: int | datetime | None = None,
+async def light(
+    self,
+    *,
+    brightness: int | None = None,
+    on: bool | None = None,
+    sleep: int | datetime | None = None,
+):
+    """Change Fans Light state."""
+    if self._device is None:
+        await self.update()
+
+    if brightness is not None and (
+        not isinstance(brightness, int)
+        or int(brightness) < LIGHT_BRIGHTNESS_LOW_VALUE
+        or int(brightness) > LIGHT_BRIGHTNESS_HIGH_VALUE
     ):
-        """Change Fans Light state."""
-        if self._device is None:
-            await self.update()
+        raise ModernFormsInvalidSettingsError(
+            "brightness value must be between"
+            + f" {LIGHT_BRIGHTNESS_LOW_VALUE} and {LIGHT_BRIGHTNESS_HIGH_VALUE}"
+        )
 
-        if brightness is not None and (
-            not isinstance(brightness, int)
-            or int(brightness) < LIGHT_BRIGHTNESS_LOW_VALUE
-            or int(brightness) > LIGHT_BRIGHTNESS_HIGH_VALUE
-        ):
-            raise ModernFormsInvalidSettingsError(
-                "brightness value must be between"
-                + f" {LIGHT_BRIGHTNESS_LOW_VALUE} and {LIGHT_BRIGHTNESS_HIGH_VALUE}"
-            )
+    if on is not None and not isinstance(on, bool):
+        raise ModernFormsInvalidSettingsError("on must be a boolean")
 
-        if on is not None and not isinstance(on, bool):
-            raise ModernFormsInvalidSettingsError("on must be a boolean")
+    sleep_commands: dict[str, int] = {}
+    if sleep is not None:
+        sleep_commands = self._sleep_command(
+            COMMAND_LIGHT_SLEEP_TIMER, COMMAND_LIGHT_TIMER, sleep
+        )
 
-        sleep_commands: dict[str, int] = {}
-        if sleep is not None:
-            sleep_commands = self._sleep_command(
-                COMMAND_LIGHT_SLEEP_TIMER, COMMAND_LIGHT_TIMER, sleep
-            )
+    if brightness is not None and on is True:
+        # Setting brightness and turning on in a single request makes the
+        # fan briefly show the previous brightness before jumping to the
+        # new one. Sending brightness first avoids the flash.
+        await self.request(commands={COMMAND_LIGHT_BRIGHTNESS: brightness})
+        await self.request(commands={COMMAND_LIGHT_POWER: on, **sleep_commands})
+        return
 
-        if brightness is not None and on is True:
-            # Setting brightness and turning on in a single request makes the
-            # fan briefly show the previous brightness before jumping to the
-            # new one. Sending brightness first avoids the flash.
-            await self.request(commands={COMMAND_LIGHT_BRIGHTNESS: brightness})
-            await self.request(commands={COMMAND_LIGHT_POWER: on, **sleep_commands})
-            return
+    commands: dict[str, bool | int] = {}
+    if brightness is not None:
+        commands[COMMAND_LIGHT_BRIGHTNESS] = brightness
+    if on is not None:
+        commands[COMMAND_LIGHT_POWER] = on
+    commands.update(sleep_commands)
 
-        commands: dict[str, bool | int] = {}
-        if brightness is not None:
-            commands[COMMAND_LIGHT_BRIGHTNESS] = brightness
-        if on is not None:
-            commands[COMMAND_LIGHT_POWER] = on
-        commands.update(sleep_commands)
-
-        await self.request(commands=commands)
+    await self.request(commands=commands)
 ```
 
 This preserves the original validation order (brightness, then `on`, then `sleep` via `_sleep_command`) so `test_invalid_setting` (which checks each raises `ModernFormsInvalidSettingsError` with zero HTTP calls) keeps passing unchanged.

--- a/docs/superpowers/specs/2026-07-27-light-brightness-before-on-design.md
+++ b/docs/superpowers/specs/2026-07-27-light-brightness-before-on-design.md
@@ -1,0 +1,34 @@
+# Light: Set Brightness Before Turning On
+
+## Problem
+
+[Issue #99](https://github.com/wonderslug/aiomodernforms/issues/99): calling `ModernFormsDevice.light(brightness=X, on=True)` sends a single HTTP request containing both `lightBrightness` and `lightOn` in one JSON payload. The fan's firmware appears to apply `lightOn` using the *previous* brightness value momentarily, then jump to the newly commanded brightness — producing a brief visible flash at the old brightness when a light is turned on with a new brightness in the same call.
+
+The issue proposes the fix directly: send the brightness command first, then send the "on" command as a separate call.
+
+## Scope
+
+Only the case that actually flashes: `light()` called with both `brightness is not None` and `on is True`. All other combinations (brightness alone, on alone, `on=False` + brightness, brightness/on with `on` omitted) keep today's single combined-request behavior — there's no flash to avoid in those cases, and splitting them would just add unnecessary round-trips or change behavior with no benefit (confirmed with the user during design).
+
+## Design
+
+Modify `ModernFormsDevice.light()` in `aiomodernforms/modernforms.py`:
+
+1. Validate `brightness` and `on` exactly as today (range check, boolean check) — **before** any request is sent, so invalid input never causes a partially-applied device state.
+2. Compute the `sleep` command dict (if `sleep` is given) via the existing `_sleep_command()` helper, same as today.
+3. If `brightness is not None and on is True`:
+   - Send request 1: `{COMMAND_LIGHT_BRIGHTNESS: brightness}` only.
+   - Send request 2: `{COMMAND_LIGHT_POWER: True, **sleep_commands}`.
+4. Otherwise: build the single combined `commands` dict exactly as today (brightness, on, sleep merged) and send one request.
+
+Each `self.request()` call already updates `self._device` from the response, so device state stays consistent across the two calls with no extra bookkeeping. `light()` continues to return nothing, matching its current signature — callers read `device.status` afterward.
+
+## Error Handling
+
+No new error paths are introduced. If request 1 (brightness) in the split case raises (`ModernFormsConnectionError`, `ModernFormsConnectionTimeoutError`, etc.), request 2 is never sent, leaving brightness set but the light not yet turned on. This is an inherent risk of any multi-step network operation and is not made worse by this change; there's no reasonable way to make two separate HTTP calls atomic, and no atomic combined API exists on the device.
+
+## Testing
+
+- Update the existing `test_light` test (currently asserts a single POST carrying brightness+on+sleep together) to reflect the new two-request behavior for the `on=True` + `brightness` case: request 1 carries only brightness, request 2 carries `on` + `sleep`.
+- Add a regression test confirming `brightness` + `on=False` together still produce a single combined request (unchanged behavior).
+- Add regression tests confirming brightness-only and on-only calls remain single requests (unchanged behavior).

--- a/tests/test_aiomodernforms.py
+++ b/tests/test_aiomodernforms.py
@@ -360,9 +360,9 @@ async def test_light(aresponses):
         assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER in data
         assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
         modified_response = basic_response.copy()
-        modified_response[
-            STATE_LIGHT_BRIGHTNESS
-        ] = aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        modified_response[STATE_LIGHT_BRIGHTNESS] = (
+            aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
         modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
         modified_response[STATE_LIGHT_SLEEP_TIMER] = data[
             aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER
@@ -480,6 +480,58 @@ async def test_light_on_only_single_request(aresponses):
         await device.update()
         await device.light(on=aiomodernforms.LIGHT_POWER_ON)
         assert device.status.light_on == aiomodernforms.LIGHT_POWER_ON
+
+
+@pytest.mark.asyncio
+async def test_light_on_with_brightness_no_sleep(aresponses):
+    """Test that turning on with brightness but no sleep still splits requests."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_brightness_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        assert aiomodernforms.COMMAND_LIGHT_POWER not in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    async def evaluate_on_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER not in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_BRIGHTNESS] = (
+            aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_brightness_request)
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_on_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(
+            on=aiomodernforms.LIGHT_POWER_ON,
+            brightness=aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE,
+        )
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_ON
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_aiomodernforms.py
+++ b/tests/test_aiomodernforms.py
@@ -335,20 +335,35 @@ async def test_command(aresponses):
 
 @pytest.mark.asyncio
 async def test_light(aresponses):
-    """Test to make sure setting lights works."""
+    """Test that turning on with a brightness sends brightness before on."""
     aresponses.add("fan.local", "/mf", "POST", response=basic_info)
     aresponses.add("fan.local", "/mf", "POST", response=basic_response)
 
-    async def evaluate_request(request):
+    async def evaluate_brightness_request(request):
         data = await request.json()
-        assert aiomodernforms.COMMAND_LIGHT_POWER in data
         assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
-        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER in data
+        assert aiomodernforms.COMMAND_LIGHT_POWER not in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER not in data
         modified_response = basic_response.copy()
-        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
         modified_response[STATE_LIGHT_BRIGHTNESS] = data[
             aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
         ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    async def evaluate_on_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
+        modified_response = basic_response.copy()
+        modified_response[
+            STATE_LIGHT_BRIGHTNESS
+        ] = aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
         modified_response[STATE_LIGHT_SLEEP_TIMER] = data[
             aiomodernforms.COMMAND_LIGHT_SLEEP_TIMER
         ]
@@ -358,7 +373,8 @@ async def test_light(aresponses):
             text=json.dumps(modified_response),
         )
 
-    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_brightness_request)
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_on_request)
 
     async with aiomodernforms.ModernFormsDevice("fan.local") as device:
         await device.update()
@@ -373,6 +389,97 @@ async def test_light(aresponses):
             device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
         )
         assert device.status.light_sleep_timer == int(sleep_time.timestamp())
+
+
+@pytest.mark.asyncio
+async def test_light_off_with_brightness_single_request(aresponses):
+    """Test that turning off with a brightness change stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(
+            on=aiomodernforms.LIGHT_POWER_OFF,
+            brightness=aiomodernforms.LIGHT_BRIGHTNESS_LOW_VALUE,
+        )
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_OFF
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_LOW_VALUE
+        )
+
+
+@pytest.mark.asyncio
+async def test_light_brightness_only_single_request(aresponses):
+    """Test that changing only brightness stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS in data
+        assert aiomodernforms.COMMAND_LIGHT_POWER not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_BRIGHTNESS] = data[
+            aiomodernforms.COMMAND_LIGHT_BRIGHTNESS
+        ]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(brightness=aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE)
+        assert (
+            device.status.light_brightness == aiomodernforms.LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+
+
+@pytest.mark.asyncio
+async def test_light_on_only_single_request(aresponses):
+    """Test that turning on without a brightness stays a single request."""
+    aresponses.add("fan.local", "/mf", "POST", response=basic_info)
+    aresponses.add("fan.local", "/mf", "POST", response=basic_response)
+
+    async def evaluate_request(request):
+        data = await request.json()
+        assert aiomodernforms.COMMAND_LIGHT_POWER in data
+        assert aiomodernforms.COMMAND_LIGHT_BRIGHTNESS not in data
+        modified_response = basic_response.copy()
+        modified_response[STATE_LIGHT_POWER] = data[aiomodernforms.COMMAND_LIGHT_POWER]
+        return aresponses.Response(
+            status=200,
+            content_type="application/json",
+            text=json.dumps(modified_response),
+        )
+
+    aresponses.add("fan.local", "/mf", "POST", response=evaluate_request)
+
+    async with aiomodernforms.ModernFormsDevice("fan.local") as device:
+        await device.update()
+        await device.light(on=aiomodernforms.LIGHT_POWER_ON)
+        assert device.status.light_on == aiomodernforms.LIGHT_POWER_ON
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes #99: turning a light on with a new brightness (`light(brightness=X, on=True)`) sent both fields in one HTTP request, and the fan's firmware briefly flashed the old brightness before applying the new one.
- `light()` now sends brightness in its own request first, then a second request with `on` (and `sleep`, if given), only for the `brightness is not None and on is True` combination. Every other combination (brightness alone, on alone, `on=False` + brightness) still sends a single combined request.
- Design spec and implementation plan included under `docs/superpowers/specs/` and `docs/superpowers/plans/` for reference.

## Test plan
- [x] `pytest tests/test_aiomodernforms.py` — 53/53 passing
- [x] `pre-commit run --all-files` equivalent (black, isort, flake8, mypy, pylint) — clean
- [x] New/updated tests assert real HTTP request ordering and payload shape via `aresponses`, including a regression test confirming `on=False` + brightness stays a single request, and a dedicated test for the split path with no `sleep` argument