### PR TITLE
Add mock fan service for client development/testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,20 +36,21 @@ lint: lint-black lint-flake8 lint-pylint lint-mypy ## Run all linters.
 
 .PHONY: lint-black
 lint-black: ## Run linting using black & blacken-docs.
-	black --safe --target-version py36 aiomodernforms tests examples diagnose.py; \
+	black --safe --target-version py36 aiomodernforms mock_fan tests examples diagnose.py; \
 	blacken-docs --target-version py36
 
 .PHONY: lint-flake8
 lint-flake8: ## Run linting using flake8 (pycodestyle/pydocstyle).
-	flake8 aiomodernforms examples tests diagnose.py
+	flake8 aiomodernforms mock_fan examples tests diagnose.py
 
 .PHONY: lint-pylint
 lint-pylint: ## Run linting using PyLint.
-	pylint aiomodernforms examples tests diagnose.py
+	pylint aiomodernforms mock_fan examples tests diagnose.py
 
 .PHONY: lint-mypy
 lint-mypy: ## Run linting using MyPy.
-	mypy -p aiomodernforms
+	mypy -p aiomodernforms; \
+	mypy -p mock_fan
 
 .PHONY: diagnose
 diagnose: ## Print a redacted fan compatibility report (usage: make diagnose HOST=<ip>).
@@ -58,6 +59,14 @@ diagnose: ## Print a redacted fan compatibility report (usage: make diagnose HOS
 		exit 1; \
 	fi
 	python diagnose.py $(HOST)
+
+.PHONY: mock-fan
+mock-fan: ## Run a mock fan server (usage: make mock-fan GENERATION=gen3 [BREEZE=1] [PORT=8080]).
+	@if [ -z "$(GENERATION)" ]; then \
+		echo "Usage: make mock-fan GENERATION=<gen1_2|gen3> [BREEZE=1] [PORT=8080]"; \
+		exit 1; \
+	fi
+	python -m mock_fan --generation $(GENERATION) --port $${PORT:-8080} $(if $(BREEZE),--breeze,)
 
 .PHONY: test
 test: ## Run tests quickly with the default Python.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ helps pinpoint model/generation differences. It redacts your account email,
 AWS identity, MAC address, device name, and certificate ID, and never
 includes the fan's IP address, so the output is safe to paste as-is. Still,
 give it a quick read before posting.
+
+## Mock fan for development
+
+To develop or test a client (such as a Home Assistant integration) against
+this API without real hardware, run a mock fan that speaks the same wire
+protocol:
+
+```bash
+python -m mock_fan --generation gen3 --breeze --port 8080
+# or
+make mock-fan GENERATION=gen1_2 PORT=8081
+```
+
+`--generation` is `gen1_2` or `gen3` and is required; `--breeze` optionally
+enables breeze/wind mode support; `--no-light` simulates a fan-only unit
+with no light kit (light is on by default). Point your client at the
+printed host/port exactly as you would a real fan.

--- a/docs/superpowers/plans/2026-07-28-mock-fan-light-toggle.md
+++ b/docs/superpowers/plans/2026-07-28-mock-fan-light-toggle.md
@@ -1,0 +1,544 @@
+# Mock Fan Light Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--light`/`--no-light` toggle to the `mock_fan` service, analogous to the existing `--breeze` toggle, so a fan-only unit (no light kit) can be simulated. Unlike breeze, light defaults to **on**.
+
+**Architecture:** Thread a `light: bool = True` parameter through the same three places `breeze: bool` already flows — `FanState`, `create_app()`, and the CLI — omitting `lightOn`/`lightBrightness`/the light timer field from the dynamic shadow and its validators when `light=False`, exactly mirroring how `wind`/`windSpeed` are omitted when `breeze=False`.
+
+**Tech Stack:** Python 3.11+, `aiohttp`, `pytest` + `pytest-asyncio`, `argparse.BooleanOptionalAction` (stdlib, Python 3.9+) for the default-True CLI flag pair.
+
+## Global Constraints
+
+- Python >=3.11, use `from __future__ import annotations` and full type hints on every function/class.
+- No new dependencies — `argparse.BooleanOptionalAction` is stdlib.
+- Every `light` parameter (on `FanState.__init__`, `MockFan.__init__`, `create_app()`) **must default to `True`** — this is a correctness requirement, not a style choice: every existing call site in `tests/mock_fan/test_state.py` and `tests/mock_fan/test_server.py` calls these without a `light` argument, and must continue to pass unmodified.
+- Every module/function/class needs a one-line docstring (this repo lints for this via flake8-docstrings).
+- Reuse the existing `aiomodernforms.const` field-name constants (`COMMAND_LIGHT_POWER`, `COMMAND_LIGHT_BRIGHTNESS`, `COMMAND_LIGHT_SLEEP_TIMER`, `COMMAND_LIGHT_TIMER`) — no new constants needed, no hardcoded wire strings.
+- Tests live under `tests/mock_fan/` (this repo's `pytest.ini` restricts testpaths to `tests`).
+- This plan continues work already in progress on the `worktree-mock-fan-service` branch/worktree at `/Users/brian/development/aiomodernforms/.claude/worktrees/mock-fan-service` — do **not** create a new worktree or branch. Run all commands from that directory, using its existing venv (`.venv/bin/...`) — do not create a new venv.
+- The prior plan's final review found that `pytest` passing locally is not sufficient — `flake8`/`isort --check-only` must also be run and pass before each task is considered done, since CI's `pre-commit run --all-files` lints more broadly than a plain test run catches. Each task's verification step below includes these explicitly; do not skip them.
+- The Makefile's `lint-black`/`lint-flake8`/`lint-pylint`/`lint-mypy` targets already cover `mock_fan` (fixed in the prior plan's final review) — no Makefile changes needed in this plan.
+
+---
+
+### Task 1: Light toggle in fan state
+
+**Files:**
+- Modify: `mock_fan/state.py` (entire file — replace with the version below)
+- Test: `tests/mock_fan/test_state.py` (append new tests; existing tests unchanged)
+
+**Interfaces:**
+- Consumes: `mock_fan.generations.GenerationProfile`, `GEN1_2`, `GEN3` (already exist).
+- Produces: `FanState.__init__(self, profile: GenerationProfile, breeze: bool, light: bool = True) -> None` — the `light` parameter is new; `snapshot()`, `reset()`, `apply_commands()` signatures are unchanged. Later tasks (server) rely on this exact signature, including the `light` default.
+
+- [ ] **Step 1: Write the failing tests**
+
+First, replace the `from aiomodernforms.const import (...)` block at the top of `tests/mock_fan/test_state.py` with this (adds `COMMAND_LIGHT_POWER`, `COMMAND_LIGHT_SLEEP_TIMER`, `COMMAND_LIGHT_TIMER`, alphabetically sorted to match the file's existing style):
+
+```python
+from aiomodernforms.const import (
+    COMMAND_FAN_DIRECTION,
+    COMMAND_FAN_POWER,
+    COMMAND_FAN_SLEEP_TIMER,
+    COMMAND_FAN_SPEED,
+    COMMAND_FAN_TIMER,
+    COMMAND_LIGHT_BRIGHTNESS,
+    COMMAND_LIGHT_POWER,
+    COMMAND_LIGHT_SLEEP_TIMER,
+    COMMAND_LIGHT_TIMER,
+    COMMAND_WIND,
+    COMMAND_WIND_SPEED,
+    FAN_DIRECTION_REVERSE,
+)
+```
+
+Then append these test functions to the end of the file:
+
+```python
+def test_light_disabled_omits_light_fields_gen1_2():
+    """A light=False Gen 1/2 fan has no light-related fields in its shadow."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_POWER not in shadow
+    assert COMMAND_LIGHT_BRIGHTNESS not in shadow
+    assert COMMAND_LIGHT_SLEEP_TIMER not in shadow
+
+
+def test_light_disabled_omits_light_timer_field_gen3():
+    """A light=False Gen 3 fan omits lightTimer but keeps fanTimer."""
+    state = FanState(GEN3, breeze=False, light=False)
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_TIMER not in shadow
+    assert COMMAND_LIGHT_POWER not in shadow
+    assert shadow[COMMAND_FAN_TIMER] == 0
+
+
+def test_light_enabled_by_default():
+    """Omitting the light argument defaults to light enabled."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.snapshot()
+    assert shadow[COMMAND_LIGHT_POWER] is False
+    assert shadow[COMMAND_LIGHT_BRIGHTNESS] == 50
+
+
+def test_light_power_command_ignored_when_light_disabled():
+    """A lightOn command against a light=False fan is silently ignored."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.apply_commands({COMMAND_LIGHT_POWER: True})
+    assert COMMAND_LIGHT_POWER not in shadow
+
+
+def test_light_brightness_command_ignored_when_light_disabled():
+    """A lightBrightness command against a light=False fan is silently ignored."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.apply_commands({COMMAND_LIGHT_BRIGHTNESS: 75})
+    assert COMMAND_LIGHT_BRIGHTNESS not in shadow
+
+
+def test_reset_preserves_light_disabled():
+    """reset() keeps light disabled if the fan was constructed that way."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    state.apply_commands({COMMAND_FAN_POWER: True})
+    state.reset()
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_POWER not in shadow
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_state.py -v`
+Expected: the 6 new tests FAIL with `TypeError: FanState.__init__() got an unexpected keyword argument 'light'` (or similar) — `light` doesn't exist yet on `FanState`.
+
+- [ ] **Step 3: Replace `mock_fan/state.py` with this implementation**
+
+```python
+"""Mutable dynamic-shadow state for the mock fan, and command validation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from aiomodernforms.const import (
+    COMMAND_ADAPTIVE_LEARNING,
+    COMMAND_AWAY_MODE,
+    COMMAND_DECOMMISSION,
+    COMMAND_FACTORY_RESET,
+    COMMAND_FAN_DIRECTION,
+    COMMAND_FAN_POWER,
+    COMMAND_FAN_SLEEP_TIMER,
+    COMMAND_FAN_SPEED,
+    COMMAND_FAN_TIMER,
+    COMMAND_LIGHT_BRIGHTNESS,
+    COMMAND_LIGHT_POWER,
+    COMMAND_LIGHT_SLEEP_TIMER,
+    COMMAND_LIGHT_TIMER,
+    COMMAND_RESET_RF_PAIR_LIST,
+    COMMAND_RF_PAIR_MODE,
+    COMMAND_SCHEDULE,
+    COMMAND_WIND,
+    COMMAND_WIND_SPEED,
+    FAN_DIRECTION_FORWARD,
+    FAN_DIRECTION_REVERSE,
+    FAN_SPEED_HIGH_VALUE,
+    FAN_SPEED_LOW_VALUE,
+    LIGHT_BRIGHTNESS_HIGH_VALUE,
+    LIGHT_BRIGHTNESS_LOW_VALUE,
+    WIND_SPEED_HIGH_VALUE,
+    WIND_SPEED_LOW_VALUE,
+)
+
+from .generations import GenerationProfile
+
+
+def _is_bool(value: object) -> bool:
+    """Return whether value is strictly a bool."""
+    return isinstance(value, bool)
+
+
+def _is_non_negative_int(value: object) -> bool:
+    """Return whether value is a non-negative int (bools excluded)."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_int_in_range(low: int, high: int) -> Callable[[object], bool]:
+    """Build a validator for an int within [low, high], excluding bools."""
+
+    def _validate(value: object) -> bool:
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and low <= value <= high
+        )
+
+    return _validate
+
+
+def _is_one_of(*choices: str) -> Callable[[object], bool]:
+    """Build a validator that accepts only the given string choices."""
+    return lambda value: value in choices
+
+
+def _is_str(value: object) -> bool:
+    """Return whether value is a string."""
+    return isinstance(value, str)
+
+
+def _initial_shadow(
+    profile: GenerationProfile, breeze: bool, light: bool
+) -> dict[str, object]:
+    """Build the startup dynamic shadow dict for a profile."""
+    shadow: dict[str, object] = {
+        COMMAND_FAN_POWER: False,
+        COMMAND_FAN_SPEED: 3,
+        COMMAND_FAN_DIRECTION: FAN_DIRECTION_FORWARD,
+        COMMAND_AWAY_MODE: False,
+        COMMAND_ADAPTIVE_LEARNING: False,
+        COMMAND_RF_PAIR_MODE: False,
+        COMMAND_RESET_RF_PAIR_LIST: False,
+        COMMAND_FACTORY_RESET: False,
+        COMMAND_DECOMMISSION: False,
+        COMMAND_SCHEDULE: "",
+    }
+    if light:
+        shadow[COMMAND_LIGHT_POWER] = False
+        shadow[COMMAND_LIGHT_BRIGHTNESS] = 50
+    if profile.uses_relative_timers:
+        shadow[COMMAND_FAN_TIMER] = 0
+        if light:
+            shadow[COMMAND_LIGHT_TIMER] = 0
+    else:
+        shadow[COMMAND_FAN_SLEEP_TIMER] = 0
+        if light:
+            shadow[COMMAND_LIGHT_SLEEP_TIMER] = 0
+    if breeze:
+        shadow[COMMAND_WIND] = False
+        shadow[COMMAND_WIND_SPEED] = 2
+    return shadow
+
+
+def _build_validators(
+    profile: GenerationProfile, breeze: bool, light: bool
+) -> dict[str, Callable[[object], bool]]:
+    """Build the per-field validator map for a profile/breeze/light combination."""
+    validators: dict[str, Callable[[object], bool]] = {
+        COMMAND_FAN_POWER: _is_bool,
+        COMMAND_AWAY_MODE: _is_bool,
+        COMMAND_ADAPTIVE_LEARNING: _is_bool,
+        COMMAND_RF_PAIR_MODE: _is_bool,
+        COMMAND_RESET_RF_PAIR_LIST: _is_bool,
+        COMMAND_FAN_SPEED: _is_int_in_range(FAN_SPEED_LOW_VALUE, FAN_SPEED_HIGH_VALUE),
+        COMMAND_FAN_DIRECTION: _is_one_of(FAN_DIRECTION_FORWARD, FAN_DIRECTION_REVERSE),
+        COMMAND_SCHEDULE: _is_str,
+    }
+    if light:
+        validators[COMMAND_LIGHT_POWER] = _is_bool
+        validators[COMMAND_LIGHT_BRIGHTNESS] = _is_int_in_range(
+            LIGHT_BRIGHTNESS_LOW_VALUE, LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+    if profile.uses_relative_timers:
+        validators[COMMAND_FAN_TIMER] = _is_non_negative_int
+        if light:
+            validators[COMMAND_LIGHT_TIMER] = _is_non_negative_int
+    else:
+        validators[COMMAND_FAN_SLEEP_TIMER] = _is_non_negative_int
+        if light:
+            validators[COMMAND_LIGHT_SLEEP_TIMER] = _is_non_negative_int
+    if breeze:
+        validators[COMMAND_WIND] = _is_bool
+        validators[COMMAND_WIND_SPEED] = _is_int_in_range(
+            WIND_SPEED_LOW_VALUE, WIND_SPEED_HIGH_VALUE
+        )
+    return validators
+
+
+class FanState:
+    """Holds and mutates a mock fan's dynamic shadow state."""
+
+    def __init__(
+        self, profile: GenerationProfile, breeze: bool, light: bool = True
+    ) -> None:
+        """Initialize state with startup defaults for the given profile."""
+        self._profile = profile
+        self._breeze = breeze
+        self._light = light
+        self._validators = _build_validators(profile, breeze, light)
+        self._shadow = _initial_shadow(profile, breeze, light)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a copy of the current dynamic shadow dict."""
+        return dict(self._shadow)
+
+    def reset(self) -> None:
+        """Reset the dynamic shadow to startup defaults."""
+        self._shadow = _initial_shadow(self._profile, self._breeze, self._light)
+
+    def apply_commands(self, commands: dict[str, object]) -> dict[str, object]:
+        """Validate and apply command fields, returning the full updated shadow.
+
+        Invalid values (out of range, wrong type, or breeze-only/light-only
+        fields on a fan without that capability) are silently ignored rather
+        than erroring, mirroring how embedded firmware is expected to no-op
+        bad input rather than return an HTTP error the API reference doesn't
+        document.
+        """
+        for key, value in commands.items():
+            validator = self._validators.get(key)
+            if validator is not None and validator(value):
+                self._shadow[key] = value
+        return self.snapshot()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_state.py -v`
+Expected: PASS (23 tests: 17 existing + 6 new)
+
+- [ ] **Step 5: Lint check**
+
+Run: `.venv/bin/flake8 mock_fan/state.py tests/mock_fan/test_state.py && .venv/bin/isort --check-only mock_fan/state.py tests/mock_fan/test_state.py`
+Expected: both commands exit with no output (clean)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mock_fan/state.py tests/mock_fan/test_state.py
+git commit -m "Add light toggle to mock fan state"
+```
+
+---
+
+### Task 2: Light toggle in the HTTP server
+
+**Files:**
+- Modify: `mock_fan/server.py`
+- Test: `tests/mock_fan/test_server.py` (append one new test; existing tests unchanged)
+
+**Interfaces:**
+- Consumes: `FanState.__init__(self, profile: GenerationProfile, breeze: bool, light: bool = True) -> None` (Task 1).
+- Produces: `create_app(profile: GenerationProfile, breeze: bool, light: bool = True, resume_delay_secs: float = 5.0) -> aiohttp.web.Application` — the `light` parameter is new, inserted between `breeze` and `resume_delay_secs`; the CLI (Task 3) relies on this exact signature and default.
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test to the end of `tests/mock_fan/test_server.py` (no new imports needed — `create_app`, `GEN1_2`, `aiomodernforms`, and `pytest` are already imported in this file):
+
+```python
+@pytest.mark.asyncio
+async def test_light_disabled_ignores_light_commands():
+    """A light=False fan silently ignores light() commands end-to-end."""
+    app = create_app(GEN1_2, breeze=False, light=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.light(on=True, brightness=75)
+            assert device.status.light_on is False
+            assert device.status.light_brightness == 100
+```
+
+Note: a second test confirming light stays enabled by default (`create_app()` called without `light=`) is deliberately **not** added — `test_light_and_fan_round_trip`, already in this file and unmodified by this task, already calls `create_app(GEN1_2, breeze=False)` (no `light` argument) and asserts `device.light(on=True, brightness=75)` results in `light_on is True` / `light_brightness == 75`. That test passing is exactly the proof the default is unchanged; a second near-identical test would be redundant.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_server.py -v -k test_light_disabled_ignores_light_commands`
+Expected: FAIL with `TypeError: create_app() got an unexpected keyword argument 'light'`
+
+- [ ] **Step 3: Modify `mock_fan/server.py`**
+
+Replace the `MockFan` class (currently lines 65-75) with:
+
+```python
+class MockFan:
+    """Holds a mock fan's state and its simulated-disconnect window."""
+
+    def __init__(
+        self,
+        profile: GenerationProfile,
+        breeze: bool,
+        resume_delay_secs: float,
+        light: bool = True,
+    ) -> None:
+        """Initialize the mock fan's state for the given profile/breeze/light."""
+        self.profile = profile
+        self.state = FanState(profile, breeze, light)
+        self.resume_delay_secs = resume_delay_secs
+        self.unresponsive_until: float = 0.0
+```
+
+Replace the `create_app` function (currently lines 112-120) with:
+
+```python
+def create_app(
+    profile: GenerationProfile,
+    breeze: bool,
+    light: bool = True,
+    resume_delay_secs: float = 5.0,
+) -> web.Application:
+    """Build the aiohttp application for a mock fan of the given profile."""
+    app = web.Application()
+    app["fan"] = MockFan(profile, breeze, resume_delay_secs, light=light)
+    app.router.add_post("/mf", _handle_mf)
+    app.router.add_post("/config-read", _handle_config_read)
+    return app
+```
+
+Everything else in `mock_fan/server.py` (the `_static_info`, `_handle_mf`, `_handle_config_read` functions, and the module-level constants) is unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_server.py -v`
+Expected: PASS (9 tests: 8 existing + 1 new). The reboot/factory-reset tests will still take a few seconds each — that's expected, unrelated to this change.
+
+- [ ] **Step 5: Lint check**
+
+Run: `.venv/bin/flake8 mock_fan/server.py tests/mock_fan/test_server.py && .venv/bin/isort --check-only mock_fan/server.py tests/mock_fan/test_server.py`
+Expected: both commands exit with no output (clean)
+
+- [ ] **Step 6: Run the full suite once**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: PASS, 99 tests (92 from before this plan + 6 from Task 1 + 1 from Task 2)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mock_fan/server.py tests/mock_fan/test_server.py
+git commit -m "Add light toggle to mock fan HTTP server"
+```
+
+---
+
+### Task 3: CLI flag and documentation
+
+**Files:**
+- Modify: `mock_fan/__main__.py`
+- Modify: `README.md:84-86`
+- Test: `tests/mock_fan/test_cli.py` (append new tests; existing tests unchanged)
+
+**Interfaces:**
+- Consumes: `create_app(profile: GenerationProfile, breeze: bool, light: bool = True, resume_delay_secs: float = 5.0) -> aiohttp.web.Application` (Task 2).
+- Produces: `_parse_args()`'s returned `argparse.Namespace` gains a `.light: bool` attribute (default `True`). `main()`'s signature is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these test functions to the end of `tests/mock_fan/test_cli.py`:
+
+```python
+def test_light_defaults_to_true():
+    """--light defaults to True when neither --light nor --no-light is given."""
+    args = _parse_args(["--generation", "gen1_2"])
+    assert args.light is True
+
+
+def test_no_light_flag():
+    """--no-light sets args.light to False."""
+    args = _parse_args(["--generation", "gen1_2", "--no-light"])
+    assert args.light is False
+
+
+def test_explicit_light_flag():
+    """--light explicitly sets args.light to True."""
+    args = _parse_args(["--generation", "gen1_2", "--light"])
+    assert args.light is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_cli.py -v -k "light"`
+Expected: FAIL with `AttributeError: 'Namespace' object has no attribute 'light'`
+
+- [ ] **Step 3: Modify `mock_fan/__main__.py`**
+
+Replace this block:
+
+```text
+    parser.add_argument(
+        "--breeze",
+        action="store_true",
+        help="Enable breeze (wind) mode support.",
+    )
+    parser.add_argument(
+        "--host",
+```
+
+with:
+
+```text
+    parser.add_argument(
+        "--breeze",
+        action="store_true",
+        help="Enable breeze (wind) mode support.",
+    )
+    parser.add_argument(
+        "--light",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Enable light control (default: enabled). "
+            "Use --no-light to simulate a fan-only unit."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+```
+
+Then replace the `main()` function with:
+
+```python
+def main(argv: list[str] | None = None) -> None:
+    """Run the mock fan server until interrupted."""
+    args = _parse_args(argv)
+    profile = PROFILES[args.generation]
+    app = create_app(profile, breeze=args.breeze, light=args.light)
+    print(
+        f"Mock fan listening on {args.host}:{args.port}"
+        f" (generation={profile.name}, breeze={'on' if args.breeze else 'off'},"
+        f" light={'on' if args.light else 'off'})"
+    )
+    web.run_app(app, host=args.host, port=args.port, print=None)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/mock_fan/test_cli.py -v`
+Expected: PASS (7 tests: 4 existing + 3 new)
+
+- [ ] **Step 5: Update the README**
+
+In `README.md`, replace this paragraph (currently lines 84-86):
+
+```markdown
+`--generation` is `gen1_2` or `gen3` and is required; `--breeze` optionally
+enables breeze/wind mode support. Point your client at the printed
+host/port exactly as you would a real fan.
+```
+
+with:
+
+```markdown
+`--generation` is `gen1_2` or `gen3` and is required; `--breeze` optionally
+enables breeze/wind mode support; `--no-light` simulates a fan-only unit
+with no light kit (light is on by default). Point your client at the
+printed host/port exactly as you would a real fan.
+```
+
+- [ ] **Step 6: Manually smoke-test the CLI**
+
+Run: `.venv/bin/python -m mock_fan --generation gen1_2 --no-light --port 8091` in one terminal, then in another:
+```bash
+curl -s -X POST http://127.0.0.1:8091/mf -d '{"queryDynamicShadowData": true}' | python3 -m json.tool
+```
+Expected: the JSON response has no `lightOn`, `lightBrightness`, or `lightSleepTimer` keys. Stop the server with Ctrl-C.
+
+- [ ] **Step 7: Lint check and full suite**
+
+Run: `.venv/bin/flake8 mock_fan tests/mock_fan && .venv/bin/isort --check-only mock_fan tests/mock_fan && .venv/bin/mypy -p mock_fan && .venv/bin/pytest tests/ -q`
+Expected: flake8 and isort clean (no output), mypy clean, pytest shows 102 passed (99 from Task 2 + 3 new)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mock_fan/__main__.py tests/mock_fan/test_cli.py README.md
+git commit -m "Add --light/--no-light CLI flag to mock fan"
+```

--- a/docs/superpowers/specs/2026-07-28-mock-fan-activity-logging-design.md
+++ b/docs/superpowers/specs/2026-07-28-mock-fan-activity-logging-design.md
@@ -1,0 +1,39 @@
+# Mock Fan Activity Logging — Design
+
+## Background
+
+The `mock_fan` service currently runs silently: once started, nothing is printed except the one-time startup banner. When using it to test a Home Assistant integration, there's no way to see what requests the integration is actually making — whether it's polling status, sending commands, what those commands are, or triggering a simulated reboot/factory-reset/decommission disconnect.
+
+## Goal
+
+Log each request the mock fan handles, always on, so activity is visible in the terminal while the mock is running.
+
+## Design
+
+### Mechanism
+
+Python's standard `logging` module, not `print()`. `mock_fan/__main__.py`'s `main()` calls `logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")` before starting the server. `mock_fan/server.py` gets a module-level logger via `logging.getLogger(__name__)`.
+
+Always on at `INFO` level, no `--quiet`/`--verbose` CLI flag — the tool's whole purpose here is watching its own activity, so there's no case for silencing it in this iteration. The existing one-time startup banner in `__main__.py` stays a plain `print()`, unchanged — it's not per-request activity, converting it adds nothing.
+
+One side effect worth calling out: `aiohttp.web.run_app()` already has a built-in access logger that emits one line per request (`METHOD /path → status`) through this same `logging` module — it's just been silently dropped so far because nothing configured `logging` to a visible level. Once `basicConfig` is set, that access log starts appearing too, for free, alongside the semantic log lines below.
+
+### What gets logged
+
+All in `mock_fan/server.py`'s `_handle_mf` and `_handle_config_read`:
+
+- **A request arriving during the simulated disconnect window** (i.e. `loop.time() < fan.unresponsive_until`, before the `asyncio.sleep(DISCONNECT_HOLD_SECS)` that holds it): `"request received while unresponsive (simulated disconnect) — holding connection"`.
+- **A static info query** (`commands.get(COMMAND_QUERY_STATIC_DATA)` truthy): `"static info request"`.
+- **A disruptive command** (`reboot`/`factoryReset`/`decommission`) being triggered: logged right before the state reset and the connection hold, naming whichever of the three fired and the configured resume delay — e.g. `"reboot received — disconnecting for 5.0s"`.
+- **A command request** (the normal `apply_commands()` path): snapshot the shadow via `fan.state.snapshot()` before calling `apply_commands()`, and diff it against the returned snapshot — log only the keys whose values actually differ, e.g. `"applied changes: {'fanOn': True, 'fanSpeed': 5}"`. If nothing changed (a pure status read via `queryDynamicShadowData`, or every field in the request was invalid/rejected/already-matching), log `"status read (no changes)"` instead. This diff-based approach needs no changes to `FanState`'s interface — it's computed entirely in `server.py` from two `snapshot()` calls already available — and it naturally filters out the `queryDynamicShadowData` marker key, which was never a real shadow field and so never appears as "changed."
+- **`POST /config-read`**: `"config-read request"`.
+
+### Testing
+
+Existing tests are unaffected — none of them assert on log output, and adding `logging.basicConfig` in `main()` (not at import time) means importing `mock_fan.server` for tests doesn't configure global logging as a side effect. New tests use `caplog` (pytest's built-in log-capture fixture) against the real integration-test pattern already established in `tests/mock_fan/test_server.py`: drive the real `aiomodernforms.ModernFormsDevice` client against a real `TestServer`, and assert the expected log message appears in `caplog.records` for each of the five cases above (static info request, config-read request, applied-changes with the right diff, status-read-with-no-changes, and a disruptive command's log line). The disconnect-window "holding connection" log line reuses the existing `resume_delay_secs`-shortening pattern from `test_reboot_disconnects_then_resumes` to keep the test fast.
+
+## Out of scope
+
+- A `--quiet`/`--verbose`/`--log-level` CLI flag.
+- Suppressing or reformatting aiohttp's built-in access log.
+- Structured/JSON logging output.

--- a/docs/superpowers/specs/2026-07-28-mock-fan-light-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-28-mock-fan-light-toggle-design.md
@@ -1,0 +1,61 @@
+# Mock Fan Light Toggle — Design
+
+## Background
+
+The `mock_fan` service (see `2026-07-28-mock-fan-service-design.md`) emulates a real Modern Forms fan over HTTP, currently always including light control (`lightOn`, `lightBrightness`, and the profile-appropriate sleep/timer field) in the dynamic shadow, with no way to turn it off. Real Modern Forms/WAC fans are sold in both light-kit and fan-only variants, the same way some are sold with and without breeze/wind support — a capability the mock already models via `--breeze`. There is currently no way to simulate a fan-only unit for testing how a Home Assistant integration behaves when no light entity should exist.
+
+## Goal
+
+Add a `--light`/`--no-light` toggle to the mock fan, analogous to `--breeze`, controlling whether light-related fields are present in the dynamic shadow at all. Unlike breeze, light defaults to **on** (most fans in the field have a light kit), so the CLI needs a different shape: `argparse.BooleanOptionalAction` rather than breeze's plain `store_true`.
+
+## Design
+
+### 1. State (`mock_fan/state.py`)
+
+`FanState.__init__` gains a `light: bool` parameter alongside the existing `breeze: bool`, stored the same way (`self._light`) and threaded into both `_initial_shadow()` and `_build_validators()`, which each gain a matching `light: bool` parameter.
+
+When `light=True` (default), behavior is byte-for-byte identical to today: `lightOn`, `lightBrightness`, and the profile-appropriate timer field (`lightSleepTimer` for `uses_relative_timers=False` profiles, `lightTimer` for `uses_relative_timers=True` profiles) are present in the initial shadow and have validators in `_build_validators()`.
+
+When `light=False`, all three keys are omitted from `_initial_shadow()`'s return value, and none of the three get an entry in `_build_validators()`'s returned map. Since `apply_commands()` already silently ignores any command key with no validator entry, a `lightOn`/`lightBrightness`/timer command against a no-light fan is a no-op — exactly the same treatment `wind`/`windSpeed` already receive when `breeze=False`. `reset()` continues to call `_initial_shadow()` with the stored `self._light` flag, so a `factory_reset()`/`decommission()` on a no-light fan stays no-light afterward.
+
+Nothing else in `state.py` changes: `snapshot()` and `apply_commands()`'s bodies are untouched, since the light/breeze gating lives entirely in what keys exist in the shadow and validator dicts, not in new conditional logic inside those methods.
+
+### 2. Server (`mock_fan/server.py`)
+
+`create_app()` gains `light: bool = True`, positioned alongside the existing `breeze` and `resume_delay_secs` parameters, passed straight through to `FanState`'s constructor via `MockFan`. No other server logic changes — `/mf` and `/config-read` handling is entirely agnostic to which shadow keys exist.
+
+### 3. CLI (`mock_fan/__main__.py`)
+
+A new argument:
+
+```python
+parser.add_argument(
+    "--light",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Enable light control (default: enabled). Use --no-light to simulate a fan-only unit.",
+)
+```
+
+This single declaration produces both `--light` and `--no-light` on the command line, defaulting `args.light` to `True` when neither is passed. `main()` passes `light=args.light` to `create_app()`, and the startup confirmation line gains a `light=on|off` segment:
+
+```
+Mock fan listening on 0.0.0.0:8080 (generation=gen3, breeze=off, light=on)
+```
+
+### 4. Unaffected
+
+- `mock_fan/generations.py`: the static `lightType` field in each `GenerationProfile` is untouched — it reflects the fan model's static info response, not the dynamic light-control capability this flag toggles. A no-light mock fan still reports whatever `lightType` its profile already defines, exactly as a real fan-only unit's static info is unaffected by this flag today.
+- `POST /config-read`: has no light-related fields today (same as breeze), so nothing changes there.
+- The Makefile's `mock-fan` target and README already pass through arbitrary flags implicitly via the documented `python -m mock_fan` invocation; no changes needed there since `--light`/`--no-light` follows the same pattern `--breeze` already established.
+
+### 5. Testing
+
+- `tests/mock_fan/test_state.py`: mirror the existing breeze tests — `light=False` omits `lightOn`/`lightBrightness`/the timer field from `snapshot()`'s initial state; a `lightOn`/`lightBrightness` command against a `light=False` state is silently ignored (key absent from the resulting snapshot); `light=True` (including the implicit default via existing call sites) is unchanged, so no existing test needs modification.
+- `tests/mock_fan/test_server.py`: one integration test creating `create_app(GEN1_2, breeze=False, light=False)` and confirming, via the real `aiomodernforms.ModernFormsDevice` client, that `device.light(on=True)` does not change `device.status.light_on` after a follow-up `update()` (the command is a no-op on the wire); one confirming the default (`light` omitted from `create_app()`) preserves today's behavior.
+- `tests/mock_fan/test_cli.py`: two new assertions — `--generation gen1_2` alone yields `args.light is True`; `--generation gen1_2 --no-light` yields `args.light is False`.
+
+## Out of scope
+
+- Changing `mock_fan/generations.py`'s static `lightType` field based on the light flag (confirmed with the user: left as-is).
+- Any change to the real `aiomodernforms` client library — it already handles a fan whose state response omits `lightOn`/`lightBrightness` the same way it handles one omitting `wind`/`windSpeed`: via `dict.get()` defaults. No `has_light()` capability method exists on `Device` today (unlike `has_wind()`), and adding one is a client-library change outside this mock service's scope.

--- a/mock_fan/__init__.py
+++ b/mock_fan/__init__.py
@@ -1,0 +1,1 @@
+"""Mock Modern Forms fan HTTP server, for testing clients without real hardware."""

--- a/mock_fan/__main__.py
+++ b/mock_fan/__main__.py
@@ -1,0 +1,70 @@
+"""CLI entry point for running a mock Modern Forms fan."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from aiohttp import web
+
+from .generations import PROFILES
+from .server import create_app
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the mock fan server."""
+    parser = argparse.ArgumentParser(
+        description="Run a mock Modern Forms fan HTTP server."
+    )
+    parser.add_argument(
+        "--generation",
+        required=True,
+        choices=sorted(PROFILES),
+        help="Fan hardware generation to emulate.",
+    )
+    parser.add_argument(
+        "--breeze",
+        action="store_true",
+        help="Enable breeze (wind) mode support.",
+    )
+    parser.add_argument(
+        "--light",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Enable light control (default: enabled). "
+            "Use --no-light to simulate a fan-only unit."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host/interface to listen on (default: 0.0.0.0).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Port to listen on (default: 8080).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the mock fan server until interrupted."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    args = _parse_args(argv)
+    profile = PROFILES[args.generation]
+    app = create_app(profile, breeze=args.breeze, light=args.light)
+    print(
+        f"Mock fan listening on {args.host}:{args.port}"
+        f" (generation={profile.name}, breeze={'on' if args.breeze else 'off'},"
+        f" light={'on' if args.light else 'off'})"
+    )
+    web.run_app(app, host=args.host, port=args.port, print=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/mock_fan/generations.py
+++ b/mock_fan/generations.py
@@ -1,0 +1,91 @@
+"""Static per-generation profile data for the mock fan."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aiomodernforms.const import (
+    CONFIG_CERTIFICATE_ID,
+    CONFIG_FIRMWARE_VERSION,
+    CONFIG_FIRMWARE_VERSION_LEGACY,
+    CONFIG_HARDWARE_REVISION,
+    CONFIG_NAME,
+    CONFIG_NAME_LEGACY,
+    CONFIG_PROTOCOL,
+    CONFIG_PROTOCOL_LEGACY,
+    CONFIG_RF_VERSION,
+    CONFIG_RF_VERSION_LEGACY,
+    CONFIG_WIFI_STRENGTH,
+)
+
+# Shared placeholder certificate ID served by both generation profiles.
+_MOCK_CERTIFICATE_ID = "mockcertificateid0000000000000000000000000000000000000000"
+
+
+@dataclass(frozen=True)
+class GenerationProfile:
+    """Static, generation-specific data the mock fan serves."""
+
+    name: str
+    client_id: str
+    mac: str
+    fan_type: str
+    light_type: str
+    fan_motor_type: str
+    firmware_version: str
+    main_mcu_firmware_version: str
+    brand: int | None
+    date_code: str
+    uses_relative_timers: bool
+    config_read_response: dict[str, str | int]
+
+
+GEN1_2 = GenerationProfile(
+    name="gen1_2",
+    client_id="MF_000000000000",
+    mac="CC:CC:CC:CC:CC:CC",
+    fan_type="1818-56",
+    light_type="F6IN-120V-R1-30",
+    fan_motor_type="DC125X25",
+    firmware_version="01.03.0025",
+    main_mcu_firmware_version="01.03.3008",
+    brand=None,
+    date_code="",
+    uses_relative_timers=False,
+    config_read_response={
+        CONFIG_NAME_LEGACY: "Mock Fan",
+        CONFIG_PROTOCOL_LEGACY: "com.modernforms.fan",
+        CONFIG_HARDWARE_REVISION: "WAC_WINDERMIER_REV_5",
+        CONFIG_FIRMWARE_VERSION_LEGACY: "01.03.0025",
+        CONFIG_RF_VERSION_LEGACY: "wl0: Oct  6 2016 01:32:44 version 5.90.230.15 ",
+        CONFIG_CERTIFICATE_ID: _MOCK_CERTIFICATE_ID,
+        CONFIG_WIFI_STRENGTH: 100,
+    },
+)
+
+# Field values below (fan_type, light_type, fan_motor_type, firmware_version,
+# main_mcu_firmware_version, brand, date_code) are taken from a real Gen 3
+# fan's diagnose.py report: https://github.com/wonderslug/aiomodernforms/issues/272
+GEN3 = GenerationProfile(
+    name="gen3",
+    client_id="MF_C82B9698E5AC",
+    mac="C8:2B:96:98:E5:AC",
+    fan_type="2006-52",
+    light_type="F4IN-120V-R1-30",
+    fan_motor_type="DC156X08",
+    firmware_version="02.00.0043",
+    main_mcu_firmware_version="03.00.0000",
+    brand=1,
+    date_code="2022-11-17",
+    uses_relative_timers=True,
+    config_read_response={
+        CONFIG_NAME: "Mock Fan",
+        CONFIG_PROTOCOL: "com.modernforms.fan",
+        CONFIG_FIRMWARE_VERSION: "02.00.0043",
+        CONFIG_RF_VERSION: "v3.2.2",
+        CONFIG_CERTIFICATE_ID: _MOCK_CERTIFICATE_ID,
+        CONFIG_WIFI_STRENGTH: "-48",
+    },
+)
+
+PROFILES: dict[str, GenerationProfile] = {"gen1_2": GEN1_2, "gen3": GEN3}

--- a/mock_fan/server.py
+++ b/mock_fan/server.py
@@ -1,0 +1,157 @@
+"""aiohttp server emulating the Modern Forms fan wire protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from aiomodernforms.const import (
+    COMMAND_DECOMMISSION,
+    COMMAND_FACTORY_RESET,
+    COMMAND_QUERY_STATIC_DATA,
+    COMMAND_REBOOT,
+    INFO_BRAND,
+    INFO_CLIENT_ID,
+    INFO_DATE_CODE,
+    INFO_DEVICE_NAME,
+    INFO_FAN_MOTOR_TYPE,
+    INFO_FAN_TYPE,
+    INFO_FEDERATED_IDENTITY,
+    INFO_FIRMWARE_URL,
+    INFO_FIRMWARE_VERSION,
+    INFO_LIGHT_TYPE,
+    INFO_MAC,
+    INFO_MAIN_MCU_FIRMWARE_VERSION,
+    INFO_OWNER,
+    INFO_PRODUCT_SKU,
+    INFO_PRODUCTION_LOT_NUMBER,
+)
+
+from .generations import GenerationProfile
+from .state import FanState
+
+# Far longer than any sane client timeout, so a held connection is
+# effectively dead from the client's point of view; short enough that an
+# abandoned handler task doesn't linger indefinitely if never cancelled.
+DISCONNECT_HOLD_SECS = 300
+
+DEVICE_NAME = "Mock Fan"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _static_info(profile: GenerationProfile, light: bool) -> dict[str, object]:
+    """Build the static shadow (queryStaticShadowData) response for a profile.
+
+    lightType is omitted (reported as "") when light=False, so the static
+    info and dynamic shadow always agree on whether the fan has a light —
+    matching how a real fan-only unit has no light kit installed at all.
+    """
+    info: dict[str, object] = {
+        INFO_CLIENT_ID: profile.client_id,
+        INFO_MAC: profile.mac,
+        INFO_LIGHT_TYPE: profile.light_type if light else "",
+        INFO_FAN_TYPE: profile.fan_type,
+        INFO_FAN_MOTOR_TYPE: profile.fan_motor_type,
+        INFO_PRODUCTION_LOT_NUMBER: "",
+        INFO_PRODUCT_SKU: "",
+        INFO_OWNER: "mock@example.com",
+        INFO_FEDERATED_IDENTITY: "us-east-1:00000000-0000-0000-0000-000000000000",
+        INFO_DEVICE_NAME: DEVICE_NAME,
+        INFO_FIRMWARE_VERSION: profile.firmware_version,
+        INFO_MAIN_MCU_FIRMWARE_VERSION: profile.main_mcu_firmware_version,
+        INFO_FIRMWARE_URL: "",
+    }
+    if profile.brand is not None:
+        info[INFO_BRAND] = profile.brand
+        info[INFO_DATE_CODE] = profile.date_code
+    return info
+
+
+class MockFan:
+    """Holds a mock fan's state and its simulated-disconnect window."""
+
+    def __init__(
+        self,
+        profile: GenerationProfile,
+        breeze: bool,
+        resume_delay_secs: float,
+        light: bool = True,
+    ) -> None:
+        """Initialize the mock fan's state for the given profile/breeze/light."""
+        self.profile = profile
+        self.light = light
+        self.state = FanState(profile, breeze, light)
+        self.resume_delay_secs = resume_delay_secs
+        self.unresponsive_until: float = 0.0
+
+
+async def _handle_mf(request: web.Request) -> web.Response:
+    """Handle POST /mf: static info queries, state queries, and commands."""
+    fan: MockFan = request.app["fan"]
+    loop = asyncio.get_running_loop()
+
+    if loop.time() < fan.unresponsive_until:
+        _LOGGER.info(
+            "request received while unresponsive (simulated disconnect) —"
+            " holding connection"
+        )
+        await asyncio.sleep(DISCONNECT_HOLD_SECS)
+
+    commands = await request.json()
+
+    if commands.get(COMMAND_QUERY_STATIC_DATA):
+        _LOGGER.info("static info request")
+        return web.json_response(_static_info(fan.profile, fan.light))
+
+    disruptive = (
+        commands.get(COMMAND_FACTORY_RESET)
+        or commands.get(COMMAND_DECOMMISSION)
+        or commands.get(COMMAND_REBOOT)
+    )
+    if disruptive:
+        if commands.get(COMMAND_FACTORY_RESET):
+            trigger = "factoryReset"
+            fan.state.reset()
+        elif commands.get(COMMAND_DECOMMISSION):
+            trigger = "decommission"
+            fan.state.reset()
+        else:
+            trigger = "reboot"
+        fan.unresponsive_until = loop.time() + fan.resume_delay_secs
+        _LOGGER.info(
+            "%s received — disconnecting for %.1fs", trigger, fan.resume_delay_secs
+        )
+        await asyncio.sleep(DISCONNECT_HOLD_SECS)
+
+    before = fan.state.snapshot()
+    shadow = fan.state.apply_commands(commands)
+    changed = {key: value for key, value in shadow.items() if before.get(key) != value}
+    if changed:
+        _LOGGER.info("applied changes: %s", changed)
+    else:
+        _LOGGER.info("status read (no changes)")
+    return web.json_response(shadow)
+
+
+async def _handle_config_read(request: web.Request) -> web.Response:
+    """Handle POST /config-read: generation-specific config info."""
+    fan: MockFan = request.app["fan"]
+    _LOGGER.info("config-read request")
+    return web.json_response(fan.profile.config_read_response)
+
+
+def create_app(
+    profile: GenerationProfile,
+    breeze: bool,
+    light: bool = True,
+    resume_delay_secs: float = 5.0,
+) -> web.Application:
+    """Build the aiohttp application for a mock fan of the given profile."""
+    app = web.Application()
+    app["fan"] = MockFan(profile, breeze, resume_delay_secs, light=light)
+    app.router.add_post("/mf", _handle_mf)
+    app.router.add_post("/config-read", _handle_config_read)
+    return app

--- a/mock_fan/state.py
+++ b/mock_fan/state.py
@@ -1,0 +1,174 @@
+"""Mutable dynamic-shadow state for the mock fan, and command validation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from aiomodernforms.const import (
+    COMMAND_ADAPTIVE_LEARNING,
+    COMMAND_AWAY_MODE,
+    COMMAND_DECOMMISSION,
+    COMMAND_FACTORY_RESET,
+    COMMAND_FAN_DIRECTION,
+    COMMAND_FAN_POWER,
+    COMMAND_FAN_SLEEP_TIMER,
+    COMMAND_FAN_SPEED,
+    COMMAND_FAN_TIMER,
+    COMMAND_LIGHT_BRIGHTNESS,
+    COMMAND_LIGHT_POWER,
+    COMMAND_LIGHT_SLEEP_TIMER,
+    COMMAND_LIGHT_TIMER,
+    COMMAND_RESET_RF_PAIR_LIST,
+    COMMAND_RF_PAIR_MODE,
+    COMMAND_SCHEDULE,
+    COMMAND_WIND,
+    COMMAND_WIND_SPEED,
+    FAN_DIRECTION_FORWARD,
+    FAN_DIRECTION_REVERSE,
+    FAN_SPEED_HIGH_VALUE,
+    FAN_SPEED_LOW_VALUE,
+    LIGHT_BRIGHTNESS_HIGH_VALUE,
+    LIGHT_BRIGHTNESS_LOW_VALUE,
+    WIND_SPEED_HIGH_VALUE,
+    WIND_SPEED_LOW_VALUE,
+)
+
+from .generations import GenerationProfile
+
+
+def _is_bool(value: object) -> bool:
+    """Return whether value is strictly a bool."""
+    return isinstance(value, bool)
+
+
+def _is_non_negative_int(value: object) -> bool:
+    """Return whether value is a non-negative int (bools excluded)."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_int_in_range(low: int, high: int) -> Callable[[object], bool]:
+    """Build a validator for an int within [low, high], excluding bools."""
+
+    def _validate(value: object) -> bool:
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and low <= value <= high
+        )
+
+    return _validate
+
+
+def _is_one_of(*choices: str) -> Callable[[object], bool]:
+    """Build a validator that accepts only the given string choices."""
+    return lambda value: value in choices
+
+
+def _is_str(value: object) -> bool:
+    """Return whether value is a string."""
+    return isinstance(value, str)
+
+
+def _initial_shadow(
+    profile: GenerationProfile, breeze: bool, light: bool
+) -> dict[str, object]:
+    """Build the startup dynamic shadow dict for a profile."""
+    shadow: dict[str, object] = {
+        COMMAND_FAN_POWER: False,
+        COMMAND_FAN_SPEED: 3,
+        COMMAND_FAN_DIRECTION: FAN_DIRECTION_FORWARD,
+        COMMAND_AWAY_MODE: False,
+        COMMAND_ADAPTIVE_LEARNING: False,
+        COMMAND_RF_PAIR_MODE: False,
+        COMMAND_RESET_RF_PAIR_LIST: False,
+        COMMAND_FACTORY_RESET: False,
+        COMMAND_DECOMMISSION: False,
+        COMMAND_SCHEDULE: "",
+    }
+    if light:
+        shadow[COMMAND_LIGHT_POWER] = False
+        shadow[COMMAND_LIGHT_BRIGHTNESS] = 50
+    if profile.uses_relative_timers:
+        shadow[COMMAND_FAN_TIMER] = 0
+        if light:
+            shadow[COMMAND_LIGHT_TIMER] = 0
+    else:
+        shadow[COMMAND_FAN_SLEEP_TIMER] = 0
+        if light:
+            shadow[COMMAND_LIGHT_SLEEP_TIMER] = 0
+    if breeze:
+        shadow[COMMAND_WIND] = False
+        shadow[COMMAND_WIND_SPEED] = 2
+    return shadow
+
+
+def _build_validators(
+    profile: GenerationProfile, breeze: bool, light: bool
+) -> dict[str, Callable[[object], bool]]:
+    """Build the per-field validator map for a profile/breeze/light combination."""
+    validators: dict[str, Callable[[object], bool]] = {
+        COMMAND_FAN_POWER: _is_bool,
+        COMMAND_AWAY_MODE: _is_bool,
+        COMMAND_ADAPTIVE_LEARNING: _is_bool,
+        COMMAND_RF_PAIR_MODE: _is_bool,
+        COMMAND_RESET_RF_PAIR_LIST: _is_bool,
+        COMMAND_FAN_SPEED: _is_int_in_range(FAN_SPEED_LOW_VALUE, FAN_SPEED_HIGH_VALUE),
+        COMMAND_FAN_DIRECTION: _is_one_of(FAN_DIRECTION_FORWARD, FAN_DIRECTION_REVERSE),
+        COMMAND_SCHEDULE: _is_str,
+    }
+    if light:
+        validators[COMMAND_LIGHT_POWER] = _is_bool
+        validators[COMMAND_LIGHT_BRIGHTNESS] = _is_int_in_range(
+            LIGHT_BRIGHTNESS_LOW_VALUE, LIGHT_BRIGHTNESS_HIGH_VALUE
+        )
+    if profile.uses_relative_timers:
+        validators[COMMAND_FAN_TIMER] = _is_non_negative_int
+        if light:
+            validators[COMMAND_LIGHT_TIMER] = _is_non_negative_int
+    else:
+        validators[COMMAND_FAN_SLEEP_TIMER] = _is_non_negative_int
+        if light:
+            validators[COMMAND_LIGHT_SLEEP_TIMER] = _is_non_negative_int
+    if breeze:
+        validators[COMMAND_WIND] = _is_bool
+        validators[COMMAND_WIND_SPEED] = _is_int_in_range(
+            WIND_SPEED_LOW_VALUE, WIND_SPEED_HIGH_VALUE
+        )
+    return validators
+
+
+class FanState:
+    """Holds and mutates a mock fan's dynamic shadow state."""
+
+    def __init__(
+        self, profile: GenerationProfile, breeze: bool, light: bool = True
+    ) -> None:
+        """Initialize state with startup defaults for the given profile."""
+        self._profile = profile
+        self._breeze = breeze
+        self._light = light
+        self._validators = _build_validators(profile, breeze, light)
+        self._shadow = _initial_shadow(profile, breeze, light)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a copy of the current dynamic shadow dict."""
+        return dict(self._shadow)
+
+    def reset(self) -> None:
+        """Reset the dynamic shadow to startup defaults."""
+        self._shadow = _initial_shadow(self._profile, self._breeze, self._light)
+
+    def apply_commands(self, commands: dict[str, object]) -> dict[str, object]:
+        """Validate and apply command fields, returning the full updated shadow.
+
+        Invalid values (out of range, wrong type, or breeze-only/light-only
+        fields on a fan without that capability) are silently ignored rather
+        than erroring, mirroring how embedded firmware is expected to no-op
+        bad input rather than return an HTTP error the API reference doesn't
+        document.
+        """
+        for key, value in commands.items():
+            validator = self._validators.get(key)
+            if validator is not None and validator(value):
+                self._shadow[key] = value
+        return self.snapshot()

--- a/tests/mock_fan/__init__.py
+++ b/tests/mock_fan/__init__.py
@@ -1,0 +1,1 @@
+"""This is empty to fix package for VSCode."""

--- a/tests/mock_fan/test_cli.py
+++ b/tests/mock_fan/test_cli.py
@@ -1,0 +1,55 @@
+"""Unit tests for mock_fan.__main__ argument parsing."""
+
+import pytest
+
+from mock_fan.__main__ import _parse_args
+
+
+def test_generation_is_required():
+    """--generation is required; omitting it is a usage error."""
+    with pytest.raises(SystemExit):
+        _parse_args([])
+
+
+def test_defaults():
+    """host/port/breeze default sensibly when only --generation is given."""
+    args = _parse_args(["--generation", "gen1_2"])
+    assert args.generation == "gen1_2"
+    assert args.breeze is False
+    assert args.host == "0.0.0.0"
+    assert args.port == 8080
+
+
+def test_breeze_flag_and_overrides():
+    """--breeze, --host, and --port are parsed correctly when given."""
+    args = _parse_args(
+        ["--generation", "gen3", "--breeze", "--host", "127.0.0.1", "--port", "9090"]
+    )
+    assert args.generation == "gen3"
+    assert args.breeze is True
+    assert args.host == "127.0.0.1"
+    assert args.port == 9090
+
+
+def test_invalid_generation_rejected():
+    """An unrecognized --generation value is a usage error."""
+    with pytest.raises(SystemExit):
+        _parse_args(["--generation", "gen99"])
+
+
+def test_light_defaults_to_true():
+    """--light defaults to True when neither --light nor --no-light is given."""
+    args = _parse_args(["--generation", "gen1_2"])
+    assert args.light is True
+
+
+def test_no_light_flag():
+    """--no-light sets args.light to False."""
+    args = _parse_args(["--generation", "gen1_2", "--no-light"])
+    assert args.light is False
+
+
+def test_explicit_light_flag():
+    """--light explicitly sets args.light to True."""
+    args = _parse_args(["--generation", "gen1_2", "--light"])
+    assert args.light is True

--- a/tests/mock_fan/test_generations.py
+++ b/tests/mock_fan/test_generations.py
@@ -1,0 +1,70 @@
+"""Unit tests for mock_fan.generations profile data."""
+
+from aiomodernforms.const import CONFIG_HARDWARE_REVISION, CONFIG_WIFI_STRENGTH
+from mock_fan.generations import GEN1_2, GEN3, PROFILES
+
+
+def test_gen1_2_uses_epoch_timers():
+    """Gen 1/2 profile is marked as using epoch (not relative) timers."""
+    assert GEN1_2.uses_relative_timers is False
+
+
+def test_gen3_uses_relative_timers():
+    """Gen 3 profile is marked as using relative timers."""
+    assert GEN3.uses_relative_timers is True
+
+
+def test_gen1_2_has_no_brand_or_date_code():
+    """Gen 1/2 profile has no brand/dateCode (Gen 3-only static fields)."""
+    assert GEN1_2.brand is None
+    assert GEN1_2.date_code == ""
+
+
+def test_gen3_has_brand_and_date_code():
+    """Gen 3 profile includes brand/dateCode."""
+    assert GEN3.brand == 1
+    assert GEN3.date_code == "2022-11-17"
+
+
+def test_gen3_matches_real_diagnostic_static_fields():
+    """Gen 3 static fields match a real fan's diagnose.py report.
+
+    See https://github.com/wonderslug/aiomodernforms/issues/272 — a Gen 3
+    fan with a light kit reports a nonempty lightType, unlike the earlier
+    placeholder value which came from a fan-only unit and was easy to
+    mistake for "Gen 3 fans have no light" instead of "this fixture fan
+    had none."
+    """
+    assert GEN3.fan_type == "2006-52"
+    assert GEN3.light_type == "F4IN-120V-R1-30"
+    assert GEN3.fan_motor_type == "DC156X08"
+    assert GEN3.firmware_version == "02.00.0043"
+    assert GEN3.main_mcu_firmware_version == "03.00.0000"
+
+
+def test_gen1_2_config_read_has_hardware_revision():
+    """Gen 1/2 config-read data includes a hardware revision."""
+    assert (
+        GEN1_2.config_read_response[CONFIG_HARDWARE_REVISION] == "WAC_WINDERMIER_REV_5"
+    )
+
+
+def test_gen3_config_read_has_no_hardware_revision_key():
+    """Gen 3 config-read data has no hardware revision key at all."""
+    assert CONFIG_HARDWARE_REVISION not in GEN3.config_read_response
+
+
+def test_gen1_2_wifi_strength_is_percentage_int():
+    """Gen 1/2 Wi-Fi strength is reported as a percentage integer."""
+    assert GEN1_2.config_read_response[CONFIG_WIFI_STRENGTH] == 100
+
+
+def test_gen3_wifi_strength_is_dbm_string():
+    """Gen 3 Wi-Fi strength is reported as a dBm string."""
+    assert GEN3.config_read_response[CONFIG_WIFI_STRENGTH] == "-48"
+
+
+def test_profiles_registry_maps_cli_names():
+    """PROFILES exposes both generations under their CLI --generation names."""
+    assert PROFILES["gen1_2"] is GEN1_2
+    assert PROFILES["gen3"] is GEN3

--- a/tests/mock_fan/test_server.py
+++ b/tests/mock_fan/test_server.py
@@ -1,0 +1,242 @@
+"""Integration tests: drive the mock fan server with the real aiomodernforms client."""
+
+import asyncio
+import logging
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+import aiomodernforms
+from aiomodernforms.const import FAN_DIRECTION_REVERSE
+from mock_fan.generations import GEN1_2, GEN3
+from mock_fan.server import create_app
+
+
+@pytest.mark.asyncio
+async def test_update_populates_info_and_state_gen1_2():
+    """update() against a Gen 1/2 mock fan populates Info and State correctly."""
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            assert device.info.fan_type == GEN1_2.fan_type
+            assert device.info.light_type == GEN1_2.light_type
+            assert device.status.fan_on is False
+            assert device.status.fan_speed == 3
+            assert device.has_breeze_mode() is False
+            assert device.has_relative_timers() is False
+
+
+@pytest.mark.asyncio
+async def test_update_populates_info_and_state_gen3():
+    """update() against a Gen 3 mock fan reports gen3 info/capabilities."""
+    app = create_app(GEN3, breeze=True)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            assert device.info.fan_type == GEN3.fan_type
+            assert device.info.brand == GEN3.brand
+            assert device.info.light_type == GEN3.light_type
+            assert device.has_breeze_mode() is True
+            assert device.has_relative_timers() is True
+
+
+@pytest.mark.asyncio
+async def test_light_type_empty_when_light_disabled():
+    """A light=False fan reports an empty lightType, not the profile's value.
+
+    Keeps static info and the dynamic shadow in agreement about whether
+    the fan has a light, mirroring how a real fan-only unit has no light
+    kit installed at all (see GEN3's docstring reference for context).
+    """
+    app = create_app(GEN3, breeze=False, light=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            assert device.info.light_type == ""
+
+
+@pytest.mark.asyncio
+async def test_activity_logging_static_info_status_and_config(caplog):
+    """update() and config() log a static info, status read, and config-read line."""
+    caplog.set_level(logging.INFO)
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.config()
+
+    assert "static info request" in caplog.text
+    assert "status read (no changes)" in caplog.text
+    assert "config-read request" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_activity_logging_applied_changes(caplog):
+    """A command that changes state logs the changed fields."""
+    caplog.set_level(logging.INFO)
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.fan(on=True, speed=5)
+
+    assert "applied changes:" in caplog.text
+    assert "'fanOn': True" in caplog.text
+    assert "'fanSpeed': 5" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_activity_logging_disruptive_command_and_hold(caplog):
+    """A reboot logs the trigger, then a follow-up request logs the held connection."""
+    caplog.set_level(logging.INFO)
+    # Long enough that the two backoff-retry sequences below (reboot's own,
+    # then the follow-up update()'s) can't outrun the disconnect window —
+    # neither actually waits this long, they just need the window still
+    # open when the second one fires.
+    app = create_app(GEN1_2, breeze=False, resume_delay_secs=20.0)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host,
+            port=client.port,
+            session=client.session,
+            request_timeout=0.2,
+        ) as device:
+            await device.update()
+            await device.reboot()  # must not raise; timeout is swallowed
+
+            with pytest.raises(aiomodernforms.ModernFormsConnectionTimeoutError):
+                await device.update()  # still inside the disconnect window
+
+    assert "reboot received — disconnecting for 20.0s" in caplog.text
+    assert "holding connection" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_light_and_fan_round_trip():
+    """light()/fan() commands round-trip through the mock fan."""
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.light(on=True, brightness=75)
+            assert device.status.light_on is True
+            assert device.status.light_brightness == 75
+
+            await device.fan(on=True, speed=5, direction=FAN_DIRECTION_REVERSE)
+            assert device.status.fan_on is True
+            assert device.status.fan_speed == 5
+            assert device.status.fan_direction == FAN_DIRECTION_REVERSE
+
+
+@pytest.mark.asyncio
+async def test_away_and_adaptive_learning_round_trip():
+    """away()/adaptive_learning() commands round-trip through the mock fan."""
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.away(True)
+            assert device.status.away_mode_enabled is True
+
+            await device.adaptive_learning(True)
+            assert device.status.adaptive_learning_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_config_read_gen1_2():
+    """config() against a Gen 1/2 mock fan returns gen1/2-shaped fields."""
+    app = create_app(GEN1_2, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            config = await device.config()
+            assert config.protocol == "com.modernforms.fan"
+            assert config.hardware_revision == "WAC_WINDERMIER_REV_5"
+            assert config.wifi_strength == "100"
+
+
+@pytest.mark.asyncio
+async def test_config_read_gen3():
+    """config() against a Gen 3 mock fan returns gen3-shaped fields."""
+    app = create_app(GEN3, breeze=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            config = await device.config()
+            assert config.protocol == "com.modernforms.fan"
+            assert config.hardware_revision == ""
+            assert config.firmware_version == "02.00.0043"
+            assert config.wifi_strength == "-48"
+
+
+@pytest.mark.asyncio
+async def test_reboot_disconnects_then_resumes():
+    """reboot() times out (swallowed) then the fan resumes responding."""
+    app = create_app(GEN1_2, breeze=False, resume_delay_secs=0.05)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host,
+            port=client.port,
+            session=client.session,
+            request_timeout=0.2,
+        ) as device:
+            await device.update()
+            await device.reboot()  # must not raise; timeout is swallowed
+
+            await asyncio.sleep(0.1)
+            await device.update()  # must succeed again after resume delay
+            assert device.status.fan_on is False
+
+
+@pytest.mark.asyncio
+async def test_factory_reset_resets_state():
+    """factory_reset() resets dynamic shadow state to startup defaults."""
+    app = create_app(GEN1_2, breeze=False, resume_delay_secs=0.05)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host,
+            port=client.port,
+            session=client.session,
+            request_timeout=0.2,
+        ) as device:
+            await device.update()
+            await device.fan(on=True, speed=6)
+            assert device.status.fan_on is True
+
+            await device.factory_reset()  # must not raise
+
+            await asyncio.sleep(0.1)
+            await device.update()
+            assert device.status.fan_on is False
+            assert device.status.fan_speed == 3
+
+
+@pytest.mark.asyncio
+async def test_light_disabled_ignores_light_commands():
+    """A light=False fan silently ignores light() commands end-to-end."""
+    app = create_app(GEN1_2, breeze=False, light=False)
+    async with TestClient(TestServer(app)) as client:
+        async with aiomodernforms.ModernFormsDevice(
+            client.host, port=client.port, session=client.session
+        ) as device:
+            await device.update()
+            await device.light(on=True, brightness=75)
+            assert device.status.light_on is False
+            assert device.status.light_brightness == 100

--- a/tests/mock_fan/test_state.py
+++ b/tests/mock_fan/test_state.py
@@ -1,0 +1,196 @@
+"""Unit tests for mock_fan.state.FanState."""
+
+from aiomodernforms.const import (
+    COMMAND_FAN_DIRECTION,
+    COMMAND_FAN_POWER,
+    COMMAND_FAN_SLEEP_TIMER,
+    COMMAND_FAN_SPEED,
+    COMMAND_FAN_TIMER,
+    COMMAND_LIGHT_BRIGHTNESS,
+    COMMAND_LIGHT_POWER,
+    COMMAND_LIGHT_SLEEP_TIMER,
+    COMMAND_LIGHT_TIMER,
+    COMMAND_WIND,
+    COMMAND_WIND_SPEED,
+    FAN_DIRECTION_REVERSE,
+)
+from mock_fan.generations import GEN1_2, GEN3
+from mock_fan.state import FanState
+
+
+def test_initial_state_gen1_2_uses_epoch_timer_fields():
+    """Gen 1/2 fans start with epoch sleep-timer fields, not relative ones."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.snapshot()
+    assert shadow[COMMAND_FAN_SLEEP_TIMER] == 0
+    assert COMMAND_FAN_TIMER not in shadow
+    assert COMMAND_WIND not in shadow
+
+
+def test_initial_state_gen3_uses_relative_timer_fields():
+    """Gen 3 fans start with relative fanTimer/lightTimer fields."""
+    state = FanState(GEN3, breeze=False)
+    shadow = state.snapshot()
+    assert shadow[COMMAND_FAN_TIMER] == 0
+    assert COMMAND_FAN_SLEEP_TIMER not in shadow
+
+
+def test_breeze_enabled_adds_wind_fields():
+    """Enabling breeze mode adds wind/windSpeed fields with defaults."""
+    state = FanState(GEN1_2, breeze=True)
+    shadow = state.snapshot()
+    assert shadow[COMMAND_WIND] is False
+    assert shadow[COMMAND_WIND_SPEED] == 2
+
+
+def test_apply_valid_fan_speed():
+    """A valid fanSpeed command is applied."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_SPEED: 6})
+    assert shadow[COMMAND_FAN_SPEED] == 6
+
+
+def test_apply_out_of_range_fan_speed_is_ignored():
+    """An out-of-range fanSpeed command is silently ignored, not applied."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_SPEED: 7})
+    assert shadow[COMMAND_FAN_SPEED] == 3
+
+
+def test_apply_non_integer_fan_speed_is_ignored():
+    """A non-integer fanSpeed command is silently ignored."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_SPEED: "six"})
+    assert shadow[COMMAND_FAN_SPEED] == 3
+
+
+def test_apply_out_of_range_light_brightness_is_ignored():
+    """An out-of-range lightBrightness command is silently ignored."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_LIGHT_BRIGHTNESS: 101})
+    assert shadow[COMMAND_LIGHT_BRIGHTNESS] == 50
+
+
+def test_apply_invalid_fan_direction_is_ignored():
+    """An unrecognized fanDirection value is silently ignored."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_DIRECTION: "sideways"})
+    assert shadow[COMMAND_FAN_DIRECTION] != "sideways"
+
+
+def test_apply_valid_fan_direction():
+    """A valid fanDirection command is applied."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_DIRECTION: FAN_DIRECTION_REVERSE})
+    assert shadow[COMMAND_FAN_DIRECTION] == FAN_DIRECTION_REVERSE
+
+
+def test_wind_command_ignored_when_breeze_disabled():
+    """A wind command against a non-breeze fan is silently ignored."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_WIND: True})
+    assert COMMAND_WIND not in shadow
+
+
+def test_wind_command_applied_when_breeze_enabled():
+    """A valid wind command against a breeze-enabled fan is applied."""
+    state = FanState(GEN1_2, breeze=True)
+    shadow = state.apply_commands({COMMAND_WIND: True, COMMAND_WIND_SPEED: 3})
+    assert shadow[COMMAND_WIND] is True
+    assert shadow[COMMAND_WIND_SPEED] == 3
+
+
+def test_apply_out_of_range_wind_speed_is_ignored():
+    """An out-of-range windSpeed command is silently ignored."""
+    state = FanState(GEN1_2, breeze=True)
+    shadow = state.apply_commands({COMMAND_WIND_SPEED: 4})
+    assert shadow[COMMAND_WIND_SPEED] == 2
+
+
+def test_apply_fan_power_boolean():
+    """A valid fanOn boolean command is applied."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_POWER: True})
+    assert shadow[COMMAND_FAN_POWER] is True
+
+
+def test_apply_non_boolean_fan_power_is_ignored():
+    """A non-boolean fanOn command is silently ignored."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_POWER: "yes"})
+    assert shadow[COMMAND_FAN_POWER] is False
+
+
+def test_reset_restores_startup_defaults():
+    """reset() restores the dynamic shadow to its startup defaults."""
+    state = FanState(GEN1_2, breeze=False)
+    state.apply_commands({COMMAND_FAN_POWER: True, COMMAND_FAN_SPEED: 6})
+    state.reset()
+    shadow = state.snapshot()
+    assert shadow[COMMAND_FAN_POWER] is False
+    assert shadow[COMMAND_FAN_SPEED] == 3
+
+
+def test_relative_timer_rejects_negative_value():
+    """A negative relative timer value is silently ignored."""
+    state = FanState(GEN3, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_TIMER: -1})
+    assert shadow[COMMAND_FAN_TIMER] == 0
+
+
+def test_relative_timer_accepts_zero_and_positive_values():
+    """Zero (cancel) and positive relative timer values are applied."""
+    state = FanState(GEN3, breeze=False)
+    shadow = state.apply_commands({COMMAND_FAN_TIMER: 120})
+    assert shadow[COMMAND_FAN_TIMER] == 120
+    shadow = state.apply_commands({COMMAND_FAN_TIMER: 0})
+    assert shadow[COMMAND_FAN_TIMER] == 0
+
+
+def test_light_disabled_omits_light_fields_gen1_2():
+    """A light=False Gen 1/2 fan has no light-related fields in its shadow."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_POWER not in shadow
+    assert COMMAND_LIGHT_BRIGHTNESS not in shadow
+    assert COMMAND_LIGHT_SLEEP_TIMER not in shadow
+
+
+def test_light_disabled_omits_light_timer_field_gen3():
+    """A light=False Gen 3 fan omits lightTimer but keeps fanTimer."""
+    state = FanState(GEN3, breeze=False, light=False)
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_TIMER not in shadow
+    assert COMMAND_LIGHT_POWER not in shadow
+    assert shadow[COMMAND_FAN_TIMER] == 0
+
+
+def test_light_enabled_by_default():
+    """Omitting the light argument defaults to light enabled."""
+    state = FanState(GEN1_2, breeze=False)
+    shadow = state.snapshot()
+    assert shadow[COMMAND_LIGHT_POWER] is False
+    assert shadow[COMMAND_LIGHT_BRIGHTNESS] == 50
+
+
+def test_light_power_command_ignored_when_light_disabled():
+    """A lightOn command against a light=False fan is silently ignored."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.apply_commands({COMMAND_LIGHT_POWER: True})
+    assert COMMAND_LIGHT_POWER not in shadow
+
+
+def test_light_brightness_command_ignored_when_light_disabled():
+    """A lightBrightness command against a light=False fan is silently ignored."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    shadow = state.apply_commands({COMMAND_LIGHT_BRIGHTNESS: 75})
+    assert COMMAND_LIGHT_BRIGHTNESS not in shadow
+
+
+def test_reset_preserves_light_disabled():
+    """reset() keeps light disabled if the fan was constructed that way."""
+    state = FanState(GEN1_2, breeze=False, light=False)
+    state.apply_commands({COMMAND_FAN_POWER: True})
+    state.reset()
+    shadow = state.snapshot()
+    assert COMMAND_LIGHT_POWER not in shadow


### PR DESCRIPTION
## Summary
- Adds `mock_fan`, an aiohttp server that speaks the same wire protocol as a real Modern Forms fan, so clients (e.g. a Home Assistant integration) can be developed/tested without hardware
- Supports both `gen1_2` and `gen3` generation profiles, with optional `--breeze` (wind mode) and `--light`/`--no-light` toggles
- Adds `make mock-fan` and documents usage in the README
- Adds `tests/mock_fan/` covering state, server, CLI, and generation profiles

## Test plan
- [x] `pytest tests/` passes (107 passed)
- [ ] Manually run `make mock-fan GENERATION=gen3 --breeze` and point a client at it